### PR TITLE
Add priority field on template

### DIFF
--- a/register.js
+++ b/register.js
@@ -23,6 +23,7 @@ Reaction.registerPackage({
     collection: "Products",
     theme: "default",
     enabled: true,
+    priority: 1,
     structure: {
       template: "productsLanding",
       layoutHeader: "layoutHeader",


### PR DESCRIPTION
Following [#2023](https://github.com/reactioncommerce/reaction/pull/2023), default priority field is `999`.
This PR sets priority of 1 on the template used to give it precedence over any matching template.