### PR TITLE
Set products to be an array of products, not a cursor

### DIFF
--- a/client/templates/products/productsLanding.js
+++ b/client/templates/products/productsLanding.js
@@ -88,7 +88,7 @@ Template.productsLanding.onCreated(function () {
     });
 
     this.state.set("canLoadMoreProducts", products.count() >= Session.get("productScrollLimit"));
-    this.products.set(products);
+    this.products.set(products.fetch());
   });
 
   this.autorun(() => {


### PR DESCRIPTION
The main product grid does an `if (products)` which is true if it's a cursor, but shouldn't be when it's empty.