### PR TITLE
Prevent complete page reload when navigating via tag.

### DIFF
--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -7,7 +7,12 @@ const FooterBeesKnees = () => (
   <div className="reaction-navigation-footer footer-default">
     <nav className="navbar-bottom" role="navigation">
       <div className="row">
-        <a href={Reaction.Router.pathFor("about")}>About Us</a>
+        <a href="javascript: void(0)" onClick={() => {
+            const path = Reaction.Router.pathFor("about");
+            Reaction.Router.go(path);
+            return false;
+          }
+        }>About Us</a>
       </div>
     </nav>
   </div>

--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from 'react-router-dom'
+import { Link } from "react-router-dom";
 
 import { replaceComponent } from "/imports/plugins/core/components/lib";
 import { Reaction } from "/client/api";

--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from 'react-router-dom'
 
 import { replaceComponent } from "/imports/plugins/core/components/lib";
 import { Reaction } from "/client/api";
@@ -7,13 +8,7 @@ const FooterBeesKnees = () => (
   <div className="reaction-navigation-footer footer-default">
     <nav className="navbar-bottom" role="navigation">
       <div className="row">
-        <a href="#" onClick={(event) => {
-            event.preventDefault();
-            const path = Reaction.Router.pathFor("about");
-            Reaction.Router.go(path);
-            return false;
-          }
-        }>About Us</a>
+        <Link to={Reaction.Router.pathFor("about")}>About Us</Link>
       </div>
     </nav>
   </div>

--- a/client/components/footer.js
+++ b/client/components/footer.js
@@ -7,7 +7,8 @@ const FooterBeesKnees = () => (
   <div className="reaction-navigation-footer footer-default">
     <nav className="navbar-bottom" role="navigation">
       <div className="row">
-        <a href="javascript: void(0)" onClick={() => {
+        <a href="#" onClick={(event) => {
+            event.preventDefault();
             const path = Reaction.Router.pathFor("about");
             Reaction.Router.go(path);
             return false;


### PR DESCRIPTION
Closes issue #26.
Prevent complete page reload when navigating via <a> tag.