### PR TITLE
Fix #30: plugin compatible with 1.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ versions.json
 .npm
 .idea
 
+node_modules
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ versions.json
 .idea
 
 node_modules
-

--- a/client/components/availabilityMap.js
+++ b/client/components/availabilityMap.js
@@ -1,14 +1,28 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { DocHead } from "meteor/kadira:dochead";
+import loadScript from "load-script";
 import { $ } from "meteor/jquery";
 import { i18next } from "/client/api";
 
 
 class AvailabilityMap extends React.Component {
   static propTypes = {
+    product: PropTypes.object,
     trackingId: PropTypes.string.isRequired
   };
+
+  componentDidMount() {
+    if (this.props.trackingId) {
+      if ($("#mapsHead").length === 0) {
+        const url = `https://maps.googleapis.com/maps/api/js?key=${this.props.trackingId}`;
+        loadScript(url, { attrs: { id: "mapsHead" } }, () => {
+          this.renderMap();
+        });
+      } else {
+        this.renderMap();
+      }
+    }
+  }
 
   renderMap() {
     // eslint-disable-next-line no-undef, no-new
@@ -29,19 +43,6 @@ class AvailabilityMap extends React.Component {
       map: googleMap,
       title: i18next.t("buyHere", "Buy here!")
     });
-  }
-
-  componentDidMount() {
-    if (this.props.trackingId) {
-      if ($("#mapsHead").length === 0) {
-        const url = `https://maps.googleapis.com/maps/api/js?key=${this.props.trackingId}`;
-        DocHead.loadScript(url, { attrs: { id: "mapsHead" } }, () => {
-          this.renderMap();
-        });
-      } else {
-        this.renderMap();
-      }
-    }
   }
 
   render() {

--- a/client/index.js
+++ b/client/index.js
@@ -5,4 +5,4 @@ import "./templates";
 import "./defaults";
 import "./init";
 import "./styles/layout.less";
-import "../lib/collections/schemas.js"
+import "../lib/collections/schemas.js";

--- a/lib/collections/accounts.js
+++ b/lib/collections/accounts.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import SimpleSchema from "simpl-schema";
 import { shopIdAutoValue } from "./helpers";
 import { Address } from "./address";
 import { Metafield } from "./metafield";

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "reaction-example-plugin",
+  "version": "1.0.0",
+  "description": "These files are for the fictional store Bee's Knees, a manufacturer of infant clothes specializing in garments made from organically grown cotton.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reactioncommerce/reaction-example-plugin.git"
+  },
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/reactioncommerce/reaction-example-plugin/issues"
+  },
+  "homepage": "https://github.com/reactioncommerce/reaction-example-plugin#readme",
+  "dependencies": {
+    "load-script": "^1.0.0"
+  },
+  "devDependencies": {
+    "@reactioncommerce/eslint-config": "^1.0.1",
+    "eslint": "^4.18.1",
+    "eslint-config-react-tools": "^1.1.2",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.7.0"
+  },
+  "eslintConfig": {
+    "extends": "@reactioncommerce",
+    "globals": {
+      "Assets": true,
+      "Package": true,
+      "FS": true,
+      "Alerts": true
+    }
+  }
+}

--- a/server/init.js
+++ b/server/init.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { check } from "meteor/check";
-import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import SimpleSchema from "simpl-schema";
 import { Packages, Shops, Products } from "/lib/collections";
 import { Product } from "/lib/collections/schemas";
 import { Hooks, Reaction, Logger } from "/server/api";
@@ -87,20 +87,18 @@ function changeProductDetailPageLayout() {
 
 function extendProductSchema() {
   Logger.info("::: Add location coordinates to simple product schema");
-  const ExtendedSchema = new SimpleSchema([Product,
+  const ExtendedSchema = Product.clone().extend(
     {
       lat: {
         optional: true,
-        type: Number,
-        decimal: true
+        type: Number
       },
       lng: {
         optional: true,
-        type: Number,
-        decimal: true
+        type: Number
       }
     }
-  ]);
+  );
   Products.attachSchema(ExtendedSchema, { replace: true, selector: { type: "simple" } });
   registerSchema("Product", ExtendedSchema);
 }


### PR DESCRIPTION
Upgraded the plugin to become compatible with release 1.9.0

Changes done -
1. Lint fix
2. Used load-script to inject <script> element into document head
3. Used `schema.extend()` because of upgrade to `simpl-schema`.